### PR TITLE
Move the icon of .desktop file so it can be themed

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -23,7 +23,9 @@ pkgbase = multimc-bin
 	noextract = multimc-bin-1.6.deb
 	source = multimc-bin-1.6.deb::https://files.multimc.org/downloads/multimc_1.6-1.deb
 	source = https://raw.githubusercontent.com/MultiMC/Launcher/f45f83173662ea8d28a6d69a5312679df76d762b/launcher/package/ubuntu/multimc/usr/share/man/man1/multimc.1
+	source = desktop-icon.patch
 	sha1sums = b943427e5f32f6a41d77a373029731c67571901d
 	sha1sums = b4f1dfc021fbf6be22b066734364a1f87ed37214
+	sha1sums = 3553ee496ae3327bc6878b455226f7df973ccf37
 
 pkgname = multimc-bin

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -35,10 +35,6 @@ package() {
     mkdir -p "$pkgdir/usr/share/man/man1"
     mkdir -p "$pkgdir/usr/share/icons/hicolor/scalable/apps"
 
-    cp -R "$srcdir/$pkgname-$pkgver/opt/multimc/" -T "$pkgdir/opt/multimc/"
-    cp -R "$srcdir/$pkgname-$pkgver/usr/share/metainfo/" -T "$pkgdir/usr/share/metainfo/"
-    cp -R "$srcdir/$pkgname-$pkgver/usr/share/applications/" -T "$pkgdir/usr/share/applications/"
-
     install -m644 -D "$srcdir/$pkgname-$pkgver/usr/share/applications/multimc.desktop" "$pkgdir/usr/share/applications/multimc.desktop"
     install -m644 -D "$srcdir/$pkgname-$pkgver/usr/share/metainfo/multimc.metainfo.xml" "$pkgdir/usr/share/metainfo/multimc.metainfo.xml"
     install -m644 -D "$srcdir/$pkgname-$pkgver/opt/multimc/icon.svg" "$pkgdir/usr/share/icons/hicolor/scalable/apps/multimc.svg"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -10,9 +10,11 @@ depends=('zlib' 'opengl-driver' 'qt5-base' 'qt5-x11extras' 'qt5-svg' 'xorg-xrand
 conflicts=('multimc' 'multimc5' 'multimc5-git')
 provides=('multimc' 'multimc5' 'multimc5-git')
 source=("$pkgname-$pkgver.deb::https://files.multimc.org/downloads/multimc_$pkgver-1.deb"
-        "https://raw.githubusercontent.com/MultiMC/Launcher/f45f83173662ea8d28a6d69a5312679df76d762b/launcher/package/ubuntu/multimc/usr/share/man/man1/multimc.1")
+        "https://raw.githubusercontent.com/MultiMC/Launcher/f45f83173662ea8d28a6d69a5312679df76d762b/launcher/package/ubuntu/multimc/usr/share/man/man1/multimc.1"
+        'desktop-icon.patch')
 sha1sums=('b943427e5f32f6a41d77a373029731c67571901d'
-          'b4f1dfc021fbf6be22b066734364a1f87ed37214')
+          'b4f1dfc021fbf6be22b066734364a1f87ed37214'
+          '3553ee496ae3327bc6878b455226f7df973ccf37')
 noextract=("$pkgname-$pkgver.deb")
 
 prepare() {
@@ -20,6 +22,9 @@ prepare() {
     bsdtar -xf $pkgname-$pkgver.deb -C "$pkgname-$pkgver"
     cd "$srcdir/$pkgname-$pkgver"
     bsdtar -xf data.tar.xz -C "$srcdir/$pkgname-$pkgver"
+
+    # Patch the .desktop file to point to the icon in /usr/share/icons
+    patch -p1 -i "${srcdir}/desktop-icon.patch"
 }
 
 package() {

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -33,11 +33,11 @@ package() {
     mkdir -p "$pkgdir/usr/share/applications"
     mkdir -p "$pkgdir/usr/bin"
     mkdir -p "$pkgdir/usr/share/man/man1"
-    mkdir -p "$pkgdir/usr/share/icons/hicolor/scalable/apps"
+    mkdir -p "$pkgdir/usr/share/pixmaps"
 
     install -m644 -D "$srcdir/$pkgname-$pkgver/usr/share/applications/multimc.desktop" "$pkgdir/usr/share/applications/multimc.desktop"
     install -m644 -D "$srcdir/$pkgname-$pkgver/usr/share/metainfo/multimc.metainfo.xml" "$pkgdir/usr/share/metainfo/multimc.metainfo.xml"
-    install -m644 -D "$srcdir/$pkgname-$pkgver/opt/multimc/icon.svg" "$pkgdir/usr/share/icons/hicolor/scalable/apps/multimc.svg"
+    install -m644 -D "$srcdir/$pkgname-$pkgver/opt/multimc/icon.svg" "$pkgdir/usr/share/pixmaps/multimc.svg"
     install -m755 -D "$srcdir/$pkgname-$pkgver/opt/multimc/run.sh" "$pkgdir/opt/multimc/run.sh"
     install -m755 -D "$srcdir/multimc.1" "$pkgdir/usr/share/man/man1/multimc.1"
     ln -s "/opt/multimc/run.sh" "$pkgdir/usr/bin/multimc"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -28,6 +28,7 @@ package() {
     mkdir -p "$pkgdir/usr/share/applications"
     mkdir -p "$pkgdir/usr/bin"
     mkdir -p "$pkgdir/usr/share/man/man1"
+    mkdir -p "$pkgdir/usr/share/icons/hicolor/scalable/apps"
 
     cp -R "$srcdir/$pkgname-$pkgver/opt/multimc/" -T "$pkgdir/opt/multimc/"
     cp -R "$srcdir/$pkgname-$pkgver/usr/share/metainfo/" -T "$pkgdir/usr/share/metainfo/"
@@ -35,7 +36,7 @@ package() {
 
     install -m644 -D "$srcdir/$pkgname-$pkgver/usr/share/applications/multimc.desktop" "$pkgdir/usr/share/applications/multimc.desktop"
     install -m644 -D "$srcdir/$pkgname-$pkgver/usr/share/metainfo/multimc.metainfo.xml" "$pkgdir/usr/share/metainfo/multimc.metainfo.xml"
-    install -m644 -D "$srcdir/$pkgname-$pkgver/opt/multimc/icon.svg" "$pkgdir/opt/multimc/icon.svg"
+    install -m644 -D "$srcdir/$pkgname-$pkgver/opt/multimc/icon.svg" "$pkgdir/usr/share/icons/hicolor/scalable/apps/multimc.svg"
     install -m755 -D "$srcdir/$pkgname-$pkgver/opt/multimc/run.sh" "$pkgdir/opt/multimc/run.sh"
     install -m755 -D "$srcdir/multimc.1" "$pkgdir/usr/share/man/man1/multimc.1"
     ln -s "/opt/multimc/run.sh" "$pkgdir/usr/bin/multimc"

--- a/desktop-icon.patch
+++ b/desktop-icon.patch
@@ -1,0 +1,13 @@
+diff --git a/usr/share/applications/multimc.desktop b/usr/share/applications/multimc.desktop
+index e0456f8..93ada57 100755
+--- a/usr/share/applications/multimc.desktop
++++ b/usr/share/applications/multimc.desktop
+@@ -1,7 +1,7 @@
+ [Desktop Entry]
+ Categories=Game;
+ Exec=/opt/multimc/run.sh
+-Icon=/opt/multimc/icon.svg
++Icon=multimc
+ Keywords=game;Minecraft;
+ MimeType=
+ Name=MultiMC 5


### PR DESCRIPTION
Currently the MultiMC icon is placed in `/opt/multimc/`, and the `.desktop` file points to it directly.
Because of that icon themes are unable to theme MMC, making it stand out in the application launcher.
This PR moves the icon over to ~~`/usr/share/icons/hicolor/scalable/apps/`~~ `/usr/share/pixmaps/` and a patch is applied to the `.desktop` file to point to `multimc` icon. This way, if a user wishes to use a theme including an icon for MMC, the theme will be picked up; otherwise it'll fall back to the bundled icon.